### PR TITLE
Add ability to directly query if a import is in progress

### DIFF
--- a/lib/portable_model.rb
+++ b/lib/portable_model.rb
@@ -16,6 +16,10 @@ module PortableModel
   #
   attr_accessor :importing_record
 
+  def currently_importing?
+    !!Thread.current[:imported_records]
+  end
+
   # Export the record to a hash.
   #
   def export_to_hash

--- a/lib/portable_model/version.rb
+++ b/lib/portable_model/version.rb
@@ -1,3 +1,3 @@
 module PortableModel
-  VERSION = "1.3.0"
+  VERSION = "1.2.2"
 end

--- a/lib/portable_model/version.rb
+++ b/lib/portable_model/version.rb
@@ -1,3 +1,3 @@
 module PortableModel
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Added `currently_importing?` that can determine if an import is in progress.

The intended use of `currently_importing?` is to act as a replacement for the check of the presence of `:importing_record` within a model, due to the fact that `:importing_record` does not get set properly when propagating the import of associated records.