### PR TITLE
Fix records with multiple :belongs_to associations not getting the correct foreign key association

### DIFF
--- a/lib/portable_model.rb
+++ b/lib/portable_model.rb
@@ -135,6 +135,7 @@ module PortableModel
               assoc_attrs.each do |assoc_name, assoc_value|
                 record.import_into_association(assoc_name, assoc_value, options)
               end
+
             end
 
             imported_records[record_hash.object_id] = record
@@ -144,7 +145,6 @@ module PortableModel
         end
       end
     end
-
 
     # Export a record from a YAML file.
     #
@@ -291,7 +291,7 @@ module PortableModel
 
       unless association_foreign_keys.empty?
         record.attributes = Hash[association_foreign_keys]
-        record.save(!options.fetch(:skip_validations, false))        
+        record.save(!options.fetch(:skip_validations, false))
       end
     end
 

--- a/lib/portable_model.rb
+++ b/lib/portable_model.rb
@@ -284,13 +284,13 @@ module PortableModel
       # Determine the foreign keys that the record owns
       association_foreign_key_list = record.class.reflect_on_all_associations(:belongs_to).map(&:association_foreign_key)
 
-      # Select the foreign keys in record_hash that belong to record, are not nil, and that record does not already possess
-      association_foreign_keys = record_hash.select do |key, value|
-        association_foreign_key_list.include?(key) && value && record[key].nil?
+      # Update the foreign keys to any associations that haven't been set yet.
+      association_foreign_keys = record_hash.reject do |key, value|
+        !association_foreign_key_list.include?(key) || value.nil? || !record[key].nil?
       end
 
       unless association_foreign_keys.empty?
-        record.attributes = Hash[association_foreign_keys]
+        record.attributes = association_foreign_keys
         record.save(!options.fetch(:skip_validations, false))
       end
     end


### PR DESCRIPTION
When models with multiple `:belongs_to` associations are imported, they do not get the correct foreign key associations. This will occur if the first instance of the model in the .yml file is imported as in one parent before its other parent has finished importing.

This is because on import, we add a record to our thread-local hash of already imported records. When referenced in a subsequent instance, we attempt to reuse the already-imported object. However, when reusing it, we miss the chance to assign another foreign key to the object.

For instance, consider a `Book` model that belongs to an `Author` and `Publisher`. In addition, `Author` belongs to `Publisher`. When importing a `Publisher`, we also import the associated `Author`, and, in the process, import `Book`. We also set the `author_id` in the `Book` model (but not the `publisher_id`!), and add it to `imported_records` in `ActiveRecord#import_portable_association`. 

Later on, when importing the `Book` model through the `Publisher`, we notice that we've already imported the `Book` object, and we reuse it, without updating the `publisher_id` attribute.

To fix this, we update the reused `record` if it has a missing foreign key that is contained within `record_hash` by checking it anytime we decide to reuse an existing record.

As a side note, this could also be fixed if we pass in some sort of hash containing the foreign keys associated with the current `record` whenever we perform a `import_into_association`.

